### PR TITLE
add: expose runner commands

### DIFF
--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -30,6 +30,8 @@ Run = function PostmanCollectionRun (state, options) { // eslint-disable-line fu
          */
         pool: Instruction.pool(Run.commands),
 
+        prototype: Run.prototype,
+
         /**
          * @private
          * @type {Object}


### PR DESCRIPTION
Making the following changes to expose the prototype commands of ```abort```, ```resume``` and ```pause``` leads to these errors newman

Adding the following code [here](https://github.com/postmanlabs/newman/blob/24d13f7a8d6e39ef75093fb3efa69cd93daa2179/lib/run/index.js#L188) gives an error as follows
```js
if (err) { return callback(err); }
run.prototype.pause((err, res) => {
      if(err) console.log(err);
});
```

![image](https://user-images.githubusercontent.com/41413622/112454985-47ce5680-8d7f-11eb-98e7-bd6849c3f56b.png)
